### PR TITLE
Modify food destroy

### DIFF
--- a/lib/models/food.js
+++ b/lib/models/food.js
@@ -22,7 +22,7 @@ function updateFood(params, id) {
 }
 
 function destroy(id) {
-  return database.raw('DELETE FROM foods WHERE id = ?', [id])
+  return database.raw('UPDATE foods SET status = 0 WHERE id = ?', [id])
 }
 
 module.exports = {

--- a/lib/models/food.js
+++ b/lib/models/food.js
@@ -3,7 +3,7 @@ const configuration = require('../../knexfile')[environment]
 const database      = require('knex')(configuration)
 
 function all() {
-  return database.raw('SELECT * FROM foods')
+  return database.raw('SELECT * FROM foods WHERE status = 1')
 }
 
 function find(id) {

--- a/test/server-test.js
+++ b/test/server-test.js
@@ -191,7 +191,7 @@ describe('Server', () => {
         const message = JSON.parse(response.body).message
         assert.equal(message, "Food successfully deleted")
 
-        return database.raw('SELECT * FROM foods').then( (data) => {
+        return database.raw('SELECT * FROM foods WHERE status = 1').then( (data) => {
           assert.equal(data.rows.length, 1)
           done();
         });
@@ -267,7 +267,7 @@ describe('Server', () => {
 
     beforeEach((done) => {
       database.raw('INSERT INTO diaries (date, created_at) VALUES (?,?)', [ new Date("9 May 2017"), new Date]).then( () => {
-        database.raw('INSERT INTO foods (name, calories, created_at) VALUES (?,?,?)', ["Banana", 34, new Date]).then( () => {
+        database.raw('INSERT INTO foods (name, calories, created_at, status) VALUES (?,?,?,?)', ["Banana", 34, new Date, 0]).then( () => {
           database.raw('INSERT INTO foods (name, calories, created_at) VALUES (?,?,?)', ["Dark Chocolate", 150, new Date]).then( () => {
             database.raw('INSERT INTO meals (name, food_id, diary_id, created_at) VALUES (?,?,?,?)', ["Lunch", 1, 1, new Date]).then( () => {
               database.raw('INSERT INTO meals (name, food_id, diary_id, created_at) VALUES (?,?,?,?)', ["Lunch", 2, 1, new Date]).then( () => {

--- a/test/server-test.js
+++ b/test/server-test.js
@@ -34,11 +34,13 @@ describe('Server', () => {
   describe('GET /api/v1/foods', () => {
 
     beforeEach((done) => {
-      database.raw('INSERT INTO foods (name, calories, created_at) VALUES (?,?,?)', ["Banana", 34, new Date]).then(() => {
-        database.raw('INSERT INTO foods (name, calories, created_at) VALUES (?,?,?)', ['Orange', 34, new Date]).then(() => {
-          done()
-        })
-      });
+      database.raw('INSERT INTO foods (name, calories, created_at, status) VALUES (?,?,?,?)', ["Donut", 500, new Date, 0]).then(() =>{
+        database.raw('INSERT INTO foods (name, calories, created_at) VALUES (?,?,?)', ["Banana", 34, new Date]).then(() => {
+          database.raw('INSERT INTO foods (name, calories, created_at) VALUES (?,?,?)', ['Orange', 34, new Date]).then(() => {
+            done()
+          })
+        });
+      })
     })
 
     afterEach((done)=>{
@@ -54,12 +56,14 @@ describe('Server', () => {
       });
     });
 
-    it('should return the correct json response', (done) => {
+    it('should return the correct json response for active foods', (done) => {
       this.request.get('/api/v1/foods', (error, response) => {
         if (error) { done(error); }
 
         let parsedFoods = JSON.parse(response.body)
 
+        assert.equal(parsedFoods[0].status, 1)
+        assert.equal(parsedFoods[1].status, 1)
         assert.equal(parsedFoods.length, 2)
         done();
       });


### PR DESCRIPTION
Modifies food destroy function to update the status of a food
to '0' indicating inactive rather than destroy it. Modifies
testing to confirm function is working as intended. Modifies
diary test to confirm that food will persist in being associated
with the diary entry(meal).
Modifies all function to return only active foods(where status =1).
Inactive item was added to test setup for that endpoint. Testing
confirms appropritae functionality via the count of foods returned
and assserting that each returned food is status = 1. All tests
currently passing.