### PR TITLE
Remove meal food endpoint

### DIFF
--- a/lib/controllers/meals-controller.js
+++ b/lib/controllers/meals-controller.js
@@ -6,6 +6,17 @@ function create(request, response) {
   })
 }
 
+function destroy(request, response) {
+  Meal.destroy(request.params.id).then( (data) => {
+    if(data.rowCount == 0){
+      response.sendStatus(404)
+    }
+    else{
+      response.json('Food Deleted from Meal')
+    }
+  })
+}
 module.exports = {
-  create: create
+  create: create,
+  destroy: destroy
 }

--- a/lib/models/diary.js
+++ b/lib/models/diary.js
@@ -20,7 +20,7 @@ function find(params) {
 }
 
 function findMeals(diaryId) {
-  return database.raw('SELECT meals.name AS meal, meals.id AS mealId, foods.id AS foodId, foods.name AS food, foods.calories AS calories FROM meals INNER JOIN foods ON meals.food_id=foods.id WHERE meals.diary_id=?', [diaryId]).then( (data) => {
+  return database.raw('SELECT meals.name AS meal, meals.id AS mealId, foods.name AS food, foods.calories AS calories FROM meals INNER JOIN foods ON meals.food_id=foods.id WHERE meals.diary_id=?', [diaryId]).then( (data) => {
     let meals = []
     if (data.rows.length == 0) {meals.push({diary_id: diaryId})}
     else {
@@ -31,7 +31,7 @@ function findMeals(diaryId) {
         meals[index] = {name: mealName, foods: [], diary_id: diaryId}
         data.rows.forEach( (mealFood) => {
           if (mealFood.meal == mealName){
-            meals[index].foods.push({name: mealFood.food, calories: mealFood.calories, meal_id: mealFood.mealid, food_id: mealFood.foodid})
+            meals[index].foods.push({name: mealFood.food, calories: mealFood.calories, meal_id: mealFood.mealid})
           }
         })
       })

--- a/lib/models/diary.js
+++ b/lib/models/diary.js
@@ -20,7 +20,7 @@ function find(params) {
 }
 
 function findMeals(diaryId) {
-  return database.raw('SELECT meals.name AS meal, foods.name AS food, foods.calories AS calories FROM meals INNER JOIN foods ON meals.food_id=foods.id WHERE meals.diary_id=?', [diaryId]).then( (data) => {
+  return database.raw('SELECT meals.name AS meal, meals.id AS mealId, foods.id AS foodId, foods.name AS food, foods.calories AS calories FROM meals INNER JOIN foods ON meals.food_id=foods.id WHERE meals.diary_id=?', [diaryId]).then( (data) => {
     let meals = []
     if (data.rows.length == 0) {meals.push({diary_id: diaryId})}
     else {
@@ -31,7 +31,7 @@ function findMeals(diaryId) {
         meals[index] = {name: mealName, foods: [], diary_id: diaryId}
         data.rows.forEach( (mealFood) => {
           if (mealFood.meal == mealName){
-            meals[index].foods.push({name: mealFood.food, calories: mealFood.calories})
+            meals[index].foods.push({name: mealFood.food, calories: mealFood.calories, meal_id: mealFood.mealid, food_id: mealFood.foodid})
           }
         })
       })

--- a/lib/models/meal.js
+++ b/lib/models/meal.js
@@ -6,6 +6,11 @@ function create(params) {
   return database.raw('INSERT INTO meals (name, diary_id, food_id, created_at) VALUES(?,?,?,?) RETURNING *', [params.name, params.diaryId, params.foodId, new Date])
 }
 
+function destroy(id){
+  return database.raw('DELETE FROM meals WHERE id = ?', [id])
+}
+
 module.exports = {
-  create: create
+  create: create,
+  destroy: destroy
 }

--- a/server.js
+++ b/server.js
@@ -27,6 +27,8 @@ app.get('/api/v1/diaries/meals', DiariesController.getData)
 
 app.post('/api/v1/meals', MealsController.create)
 
+app.delete('/api/v1/meals/:id', MealsController.destroy)
+
 app.get('/api/v1/search', FoodsController.search)
 
 

--- a/test/server-test.js
+++ b/test/server-test.js
@@ -340,6 +340,8 @@ describe('Server', () => {
           meal.foods.forEach((food) => {
             assert.ok(food.name)
             assert.ok(food.calories)
+            assert.ok(food.meal_id)
+            assert.ok(food.food_id)
           })
         })
         done()


### PR DESCRIPTION
Modifies above endpoint to also return the meal_id for each
diary-food. Test modified to confirm intended return values. All tests
remain passing.
Endpoint added at DELETE /api/v1/meals/:id.
Deletes selected meal item; this results in the food
being preserved in the foods table; however, the
association between the food and the diary is destroyed.
Tests are all currently passing.